### PR TITLE
Fix addons-dev folders not on PYTHONPATH

### DIFF
--- a/py3.6-slim-stretch/stack/install.sh
+++ b/py3.6-slim-stretch/stack/install.sh
@@ -7,6 +7,8 @@ set -e
 
 PYTHON_MAJOR_VERSION=$(python -c 'import platform; print(platform.python_version_tuple()[0])')
 
+PYTHON_SITE_PACKAGES_ROOT=$(python -c 'from distutils.sysconfig import get_python_lib; print(get_python_lib())')
+
 SCRIPT=$(readlink -f "$0")
 BASEDIR=$(dirname "$SCRIPT")
 


### PR DESCRIPTION
Previously the ``add_addons_dev_to_syspath.py`` and 
``add_addons_dev_to_syspath.pth`` files were copied to ``/`` instead of 
``/virtualenv/lib/python3.6/site-packages/`` because 
``PYTHON_SITE_PACKAGES_ROOT`` was undefined.