### PR TITLE
Upgrade Python3.6 and Python3.7 slim image to the latest

### DIFF
--- a/py3.6-slim-stretch/Dockerfile
+++ b/py3.6-slim-stretch/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.6.8-slim-stretch AS build
+FROM python:3.6.11-slim-stretch AS build
 
 ARG TARGET=prod
 

--- a/py3.7-slim-stretch/Dockerfile
+++ b/py3.7-slim-stretch/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.7.3-slim-stretch AS build
+FROM python:3.7.8-slim-stretch AS build
 
 ARG TARGET=prod
 


### PR DESCRIPTION
Python3.6 and Python3.7 has newer images that contain good improvements and bugfixes. This PR updates them to the latest available python versions.

- Relevant docker hub link: https://hub.docker.com/_/python